### PR TITLE
Demo navigation.

### DIFF
--- a/demo.cc
+++ b/demo.cc
@@ -147,7 +147,7 @@ class Cruncher final {
              "<div class=\"knsh-columns__item\" style=\"text-align: right;\">"
              "<a href=\"/" +
                  demo_id_ +
-                 "/a/\" class=\"knsh-header-link\"><span>Back to demo</span></a>"
+                 "/a/\" class=\"knsh-header-link\"><span>Actions</span></a>"
                  "</div>"},
             // Footer columns between the copyright and the GitHub link.
             {"<div class=\"knsh-columns__item\" id=\"knsh-footer-columns-placeholder\"></div>", ""},

--- a/static/actions_footer.html
+++ b/static/actions_footer.html
@@ -32,7 +32,7 @@
 
 <p style='font-size:24;text-align:center'><a href='raw'>PubSub JSON Feed</a></p>
 
-<p align=center><a href='../'><font size=+3>Dashboard</font></a></p>
+<!-- <p align=center><a href='../'><font size=+3>Dashboard</font></a></p> -->
 
 <br>
 <br>

--- a/static/actions_footer.html
+++ b/static/actions_footer.html
@@ -49,7 +49,7 @@
 						<div class="knsh-columns__item" style="text-align: right;">
 							<div class="knsh-footer-links">
 								<div class="knsh-footer-links__item">
-									<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+									<a href="https://github.com/KnowSheet/AgreeDisagreeDemo" class="knsh-footer-link"><span>Code</span></a>
 								</div>
 							</div>
 						</div>

--- a/static/actions_header.html
+++ b/static/actions_header.html
@@ -93,7 +93,6 @@
 		}
 		.knsh-theme .knsh-header-logo__caption {
 			font-size: 14px;
-			white-space: nowrap;
 		}
 		
 		.knsh-theme .knsh-footer {

--- a/static/actions_header.html
+++ b/static/actions_header.html
@@ -212,7 +212,8 @@
 							</div>
 						</div>
 						<div class="knsh-columns__item" style="text-align: right;">
-							<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+							<a href=".." class="knsh-footer-link"><span>Dashboard</span></a>
+							<a href="https://github.com/KnowSheet/KnowSheet/blob/master/static/TailProduce.pdf" class="knsh-footer-link"><span>Slides</span></a>
 						</div>
 					</div>
 				</header>

--- a/static/landing.html
+++ b/static/landing.html
@@ -93,7 +93,6 @@
 		}
 		.knsh-theme .knsh-header-logo__caption {
 			font-size: 14px;
-			white-space: nowrap;
 		}
 		
 		.knsh-theme .knsh-footer {

--- a/static/landing.html
+++ b/static/landing.html
@@ -212,7 +212,7 @@
 							</div>
 						</div>
 						<div class="knsh-columns__item" style="text-align: right;">
-							<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+							<a href="https://github.com/KnowSheet/KnowSheet/blob/master/static/TailProduce.pdf" class="knsh-footer-link"><span>Slides</span></a>
 						</div>
 					</div>
 				</header>
@@ -260,7 +260,7 @@
 						<div class="knsh-columns__item" style="text-align: right;">
 							<div class="knsh-footer-links">
 								<div class="knsh-footer-links__item">
-									<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+									<a href="https://github.com/KnowSheet/AgreeDisagreeDemo" class="knsh-footer-link"><span>Code</span></a>
 								</div>
 							</div>
 						</div>

--- a/static/template.html
+++ b/static/template.html
@@ -93,7 +93,6 @@
 		}
 		.knsh-theme .knsh-header-logo__caption {
 			font-size: 14px;
-			white-space: nowrap;
 		}
 		
 		.knsh-theme .knsh-footer {

--- a/static/template.html
+++ b/static/template.html
@@ -214,7 +214,7 @@
 						</div>
 						<div class="knsh-columns__item" id="knsh-header-columns-placeholder"></div>
 						<div class="knsh-columns__item" style="text-align: right;">
-							<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-header-link"><span>GitHub</span></a>
+							<a href="https://github.com/KnowSheet/KnowSheet/blob/master/static/TailProduce.pdf" class="knsh-footer-link"><span>Slides</span></a>
 						</div>
 					</div>
 				</header>
@@ -236,7 +236,7 @@
 						<div class="knsh-columns__item" style="text-align: right;">
 							<div class="knsh-footer-links">
 								<div class="knsh-footer-links__item">
-									<a href="https://github.com/KnowSheet/KnowSheet" class="knsh-footer-link"><span>GitHub</span></a>
+									<a href="https://github.com/KnowSheet/AgreeDisagreeDemo" class="knsh-footer-link"><span>Code</span></a>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
Hi @sompylasar,

I posted the slides, linked them from Demo's HTML and updated the GitHub link too.

Thought for a minute and removed the large "Dashboard" link as well. When showing it, I'll first go through the actions "backend", and then show the dashboard.

PTAL!

Thanks,
Dima
